### PR TITLE
Restore Magento built-in quantity check

### DIFF
--- a/app/code/local/Jarlssen/CustomCartValidation/etc/config.xml
+++ b/app/code/local/Jarlssen/CustomCartValidation/etc/config.xml
@@ -28,10 +28,10 @@
         <events>
             <sales_quote_item_qty_set_after>
                 <observers>
-                    <inventory>
+                    <jarlssen_custom_cart_validation>
                         <class>jarlssen_custom_cart_validation/observer</class>
                         <method>quoteItemValidations</method>
-                    </inventory>
+                    </jarlssen_custom_cart_validation>
                 </observers>
             </sales_quote_item_qty_set_after>
         </events>


### PR DESCRIPTION
The currently registered observer replaces the built-in quantity check.
This commit adds it back, meaning both observer methods will be executed.
